### PR TITLE
Creating the POST and ALL endpoints for Dining Commons Menu Items

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -20,6 +20,14 @@ public class UCSBDiningCommonsMenuItemController {
     this.diningCommonsMenuItemRepository = diningCommonsMenuItemRepository;
   }
 
+  /**
+   * Post a new Menu Item
+   *
+   * @param diningCommonsCode the code of the dining commons
+   * @param name the name of the menu item
+   * @param station the station where the menu item is located
+   * @return the created {@link DiningCommonsMenuItem}
+   */
   @PostMapping("/post")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   public DiningCommonsMenuItem postMenuItem(
@@ -36,6 +44,11 @@ public class UCSBDiningCommonsMenuItemController {
     return diningCommonsMenuItemRepository.save(item);
   }
 
+  /**
+   * Get all Menu Items
+   *
+   * @return a list of all {@link DiningCommonsMenuItem}
+   */
   @GetMapping("/all")
   @PreAuthorize("hasRole('ROLE_USER')")
   public Iterable<DiningCommonsMenuItem> allMenuItems() {

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -1,0 +1,44 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.DiningCommonsMenuItem;
+import edu.ucsb.cs156.example.repositories.DiningCommonsMenuItemRepository;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/ucsbdiningcommonsmenuitem")
+public class UCSBDiningCommonsMenuItemController {
+
+  private final DiningCommonsMenuItemRepository diningCommonsMenuItemRepository;
+
+  public UCSBDiningCommonsMenuItemController(
+      DiningCommonsMenuItemRepository diningCommonsMenuItemRepository) {
+    this.diningCommonsMenuItemRepository = diningCommonsMenuItemRepository;
+  }
+
+  @PostMapping("/post")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  public DiningCommonsMenuItem postMenuItem(
+      @RequestParam String diningCommonsCode,
+      @RequestParam String name,
+      @RequestParam String station) {
+    DiningCommonsMenuItem item =
+        DiningCommonsMenuItem.builder()
+            .station(station)
+            .name(name)
+            .diningCommonsCode(diningCommonsCode)
+            .build();
+
+    return diningCommonsMenuItemRepository.save(item);
+  }
+
+  @GetMapping("/all")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  public Iterable<DiningCommonsMenuItem> allMenuItems() {
+    return diningCommonsMenuItemRepository.findAll();
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.example.controllers;
 
 import edu.ucsb.cs156.example.entities.DiningCommonsMenuItem;
 import edu.ucsb.cs156.example.repositories.DiningCommonsMenuItemRepository;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "UCSBDiningCommonsMenuItem")
 @RestController
 @RequestMapping("/api/ucsbdiningcommonsmenuitem")
 public class UCSBDiningCommonsMenuItemController {

--- a/src/main/java/edu/ucsb/cs156/example/entities/DiningCommonsMenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/DiningCommonsMenuItem.java
@@ -1,0 +1,26 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+@Entity(name = "dining_commons_menu_item")
+public class DiningCommonsMenuItem {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String diningCommonsCode;
+  private String name;
+  private String station;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/DiningCommonsMenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/DiningCommonsMenuItemRepository.java
@@ -1,0 +1,9 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.DiningCommonsMenuItem;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DiningCommonsMenuItemRepository
+    extends CrudRepository<DiningCommonsMenuItem, Long> {}

--- a/src/main/resources/db/migration/changes/DiningCommonsMenuItem.json
+++ b/src/main/resources/db/migration/changes/DiningCommonsMenuItem.json
@@ -1,0 +1,62 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "Restaurants-1",
+        "author": "Division7",
+        "preConditions": [
+          {
+            "onFail": "MARK_RAN"
+          },
+          {
+            "not": [
+              {
+                "tableExists": {
+                  "tableName": "DINING_COMMONS_MENU_ITEM"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "primaryKey": true,
+                      "primaryKeyName": "DINING_COMMONS_MENU_ITEM_PK"
+                    },
+                    "name": "ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "DINING_COMMONS_CODE",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "NAME",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "STATION",
+                    "type": "VARCHAR(255)"
+                  }
+                }
+              ],
+              "tableName": "DINING_COMMONS_MENU_ITEM"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -1,0 +1,136 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.DiningCommonsMenuItem;
+import edu.ucsb.cs156.example.repositories.DiningCommonsMenuItemRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(UCSBDiningCommonsMenuItemController.class)
+@Import(TestConfig.class)
+public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase {
+
+  @MockitoBean private DiningCommonsMenuItemRepository diningCommonsMenuItemRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_menu_items() throws Exception {
+
+    DiningCommonsMenuItem item1 =
+        DiningCommonsMenuItem.builder()
+            .name("item 1")
+            .diningCommonsCode("station 1")
+            .diningCommonsCode("de-la-guerra")
+            .build();
+
+    DiningCommonsMenuItem item2 =
+        DiningCommonsMenuItem.builder()
+            .name("item 2")
+            .diningCommonsCode("station 2")
+            .diningCommonsCode("carrillo")
+            .build();
+
+    ArrayList<DiningCommonsMenuItem> expectedItems = new ArrayList<>(Arrays.asList(item1, item2));
+
+    when(diningCommonsMenuItemRepository.findAll()).thenReturn(expectedItems);
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(diningCommonsMenuItemRepository, times(1)).findAll();
+    List<DiningCommonsMenuItem> retrievedItems =
+        mapper.readValue(response.getResponse().getContentAsString(), new TypeReference<>() {});
+
+    assertTrue(retrievedItems.containsAll(expectedItems));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_post_new_menu_item() throws Exception {
+    // arrange
+
+    DiningCommonsMenuItem item =
+        DiningCommonsMenuItem.builder()
+            .name("item 1")
+            .station("station 1")
+            .diningCommonsCode("de-la-guerra")
+            .build();
+
+    when(diningCommonsMenuItemRepository.save(eq(item))).thenReturn(item);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/ucsbdiningcommonsmenuitem/post")
+                    .with(csrf())
+                    .param("name", "item 1")
+                    .param("station", "station 1")
+                    .param("diningCommonsCode", "de-la-guerra"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(diningCommonsMenuItemRepository, times(1)).save(item);
+    String expectedJson = mapper.writeValueAsString(item);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc
+        .perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+        .andExpect(status().is(403)); // logged out users can't get all
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc
+        .perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+        .andExpect(status().is(200)); // logged
+  }
+
+  // Authorization tests for /api/ucsbdiningcommonsmenuitem/post
+  // (Perhaps should also have these for put and delete)
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem/post")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(post("/api/ucsbdiningcommonsmenuitem/post"))
+        .andExpect(status().is(403)); // only admins can post
+  }
+}


### PR DESCRIPTION
In this PR, I add the POST and ALL endpoints for DiningCommonsMenuItem. They are located at `/api/ucsbdiningcommonsmenuitem/all` and `/api/ucsbdiningcommonsmenuitem/post`,  taking no parameters and (`station`, `diningCommonsCode`, and `name`) respectively.

Testing Plan:
Post a DiningCommonsMenuItem [via swagger](https://dining-division7.dokku-00.cs.ucsb.edu/swagger-ui/index.html#/UCSBDiningCommonsMenuItem/postMenuItem). Submit a `name`, `diningCommonsCode`, and `station` in the appropriate fields.
Using the SHOW endpoint, [see if it appears](https://dining-division7.dokku-00.cs.ucsb.edu/swagger-ui/index.html#/UCSBDiningCommonsMenuItem/allMenuItems).
Post another DiningCommonsMenuItem [via swagger](https://dining-division7.dokku-00.cs.ucsb.edu/swagger-ui/index.html#/UCSBDiningCommonsMenuItem/postMenuItem). Submit a `name`, `diningCommonsCode`, and `station` in the appropriate fields.
See if they both appear in the [SHOW endpoint](https://dining-division7.dokku-00.cs.ucsb.edu/swagger-ui/index.html#/UCSBDiningCommonsMenuItem/allMenuItems)! 


Closes #53 
Deployed to https://dining-division7.dokku-00.cs.ucsb.edu/

