### PR TITLE
Suppressing Automatic Endpoints on DiningCommonsMenuItemRepository

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/repositories/DiningCommonsMenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/DiningCommonsMenuItemRepository.java
@@ -2,8 +2,10 @@ package edu.ucsb.cs156.example.repositories;
 
 import edu.ucsb.cs156.example.entities.DiningCommonsMenuItem;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@RepositoryRestResource(exported = false)
 public interface DiningCommonsMenuItemRepository
     extends CrudRepository<DiningCommonsMenuItem, Long> {}


### PR DESCRIPTION
In this PR, I suppress the automatic RestResource endpoints by adding the annotation I accidentally neglected to add in #43 .
This suppresses the automatic endpoints so that we can manually create them.


Deployed to https://team01-dev-division7.dokku-00.cs.ucsb.edu/