### PR TITLE
Rec Request Controller, POST and GET

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -1,0 +1,97 @@
+package edu.ucsb.cs156.example.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** This is a REST controller for RecommendationRequests */
+@Tag(name = "RecommendationRequests")
+@RequestMapping("/api/RecommendationRequest")
+@RestController
+@Slf4j
+public class RecommendationRequestController extends ApiController {
+
+  @Autowired RecommendationRequestRepository recommendationRequestRepository;
+
+  /**
+   * List all RecommendationRequests
+   *
+   * @return an iterable of RecommendationRequest
+   */
+  @Operation(summary = "List all recommendation requests")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<RecommendationRequest> allRecommendationRequests() {
+    Iterable<RecommendationRequest> recommendationRequests =
+        recommendationRequestRepository.findAll();
+    return recommendationRequests;
+  }
+
+  /**
+   * Create a new RecommendationRequest
+   *
+   * @param requesterEmail the email of the person requesting the recommendation
+   * @param professorEmail the email of the professor receiving the request
+   * @param explanation explanation of what the recommendation is for
+   * @param dateRequested the date and time the recommendation was requested
+   * @param dateNeeded the date and time by which the recommendation is needed
+   * @param done whether the recommendation request has been completed
+   * @return the saved RecommendationRequest
+   */
+  @Operation(summary = "Create a new recommendation request")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public RecommendationRequest postRecommendationRequest(
+      @Parameter(name = "requesterEmail", description = "Email address of the requester")
+          @RequestParam
+          String requesterEmail,
+      @Parameter(name = "professorEmail", description = "Email address of the professor")
+          @RequestParam
+          String professorEmail,
+      @Parameter(name = "explanation", description = "Explanation of the recommendation request")
+          @RequestParam
+          String explanation,
+      @Parameter(
+              name = "dateRequested",
+              description = "Date and time requested in ISO format, e.g. 2022-05-20T00:00:00")
+          @RequestParam("dateRequested")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime dateRequested,
+      @Parameter(
+              name = "dateNeeded",
+              description = "Date and time needed in ISO format, e.g. 2022-11-15T00:00:00")
+          @RequestParam("dateNeeded")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime dateNeeded,
+      @Parameter(name = "done", description = "Whether the recommendation request is completed")
+          @RequestParam
+          boolean done)
+      throws JsonProcessingException {
+
+    RecommendationRequest recommendationRequest = new RecommendationRequest();
+    recommendationRequest.setRequesterEmail(requesterEmail);
+    recommendationRequest.setProfessorEmail(professorEmail);
+    recommendationRequest.setExplanation(explanation);
+    recommendationRequest.setDateRequested(dateRequested);
+    recommendationRequest.setDateNeeded(dateNeeded);
+    recommendationRequest.setDone(done);
+
+    RecommendationRequest savedRecommendationRequest =
+        recommendationRequestRepository.save(recommendationRequest);
+
+    return savedRecommendationRequest;
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -1,0 +1,153 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = RecommendationRequestController.class)
+@Import(TestConfig.class)
+public class RecommendationRequestControllerTests extends ControllerTestCase {
+
+  @MockitoBean RecommendationRequestRepository recommendationRequestRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  // Authorization tests for /api/RecommendationRequest/all
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc.perform(get("/api/RecommendationRequest/all")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/RecommendationRequest/all")).andExpect(status().is(200));
+  }
+
+  // Authorization tests for /api/RecommendationRequest/post
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc.perform(post("/api/RecommendationRequest/post")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc.perform(post("/api/RecommendationRequest/post")).andExpect(status().is(403));
+  }
+
+  // Tests with mocks for database actions
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_recommendationrequests() throws Exception {
+
+    // arrange
+    LocalDateTime dateRequested = LocalDateTime.parse("2022-05-20T00:00:00");
+    LocalDateTime dateNeeded = LocalDateTime.parse("2022-11-15T00:00:00");
+
+    RecommendationRequest recommendationRequest1 =
+        RecommendationRequest.builder()
+            .requesterEmail("ldelplaya@ucsb.edu")
+            .professorEmail("richert@ucsb.edu")
+            .explanation("PhD CS Stanford")
+            .dateRequested(dateRequested)
+            .dateNeeded(dateNeeded)
+            .done(false)
+            .build();
+
+    RecommendationRequest recommendationRequest2 =
+        RecommendationRequest.builder()
+            .requesterEmail("ldelplaya@ucsb.edu")
+            .professorEmail("phtcon@ucsb.edu")
+            .explanation("PhD CS Stanford")
+            .dateRequested(dateRequested)
+            .dateNeeded(dateNeeded)
+            .done(false)
+            .build();
+
+    ArrayList<RecommendationRequest> expectedRecommendationRequests = new ArrayList<>();
+    expectedRecommendationRequests.addAll(
+        Arrays.asList(recommendationRequest1, recommendationRequest2));
+
+    when(recommendationRequestRepository.findAll()).thenReturn(expectedRecommendationRequests);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/RecommendationRequest/all"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(recommendationRequestRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedRecommendationRequests);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_recommendationrequest() throws Exception {
+    // arrange
+    LocalDateTime dateRequested = LocalDateTime.parse("2022-05-20T00:00:00");
+    LocalDateTime dateNeeded = LocalDateTime.parse("2022-11-15T00:00:00");
+
+    RecommendationRequest recommendationRequest =
+        RecommendationRequest.builder()
+            .requesterEmail("ldelplaya@ucsb.edu")
+            .professorEmail("richert@ucsb.edu")
+            .explanation("PhD CS Stanford")
+            .dateRequested(dateRequested)
+            .dateNeeded(dateNeeded)
+            .done(true)
+            .build();
+
+    when(recommendationRequestRepository.save(eq(recommendationRequest)))
+        .thenReturn(recommendationRequest);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/RecommendationRequest/post")
+                    .param("requesterEmail", "ldelplaya@ucsb.edu")
+                    .param("professorEmail", "richert@ucsb.edu")
+                    .param("explanation", "PhD CS Stanford")
+                    .param("dateRequested", "2022-05-20T00:00:00")
+                    .param("dateNeeded", "2022-11-15T00:00:00")
+                    .param("done", "true")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(recommendationRequestRepository, times(1)).save(recommendationRequest);
+    String expectedJson = mapper.writeValueAsString(recommendationRequest);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+}


### PR DESCRIPTION
This pull request introduces a new REST controller for managing recommendation requests, along with comprehensive tests to ensure correct authorization and functionality. The main changes include implementing the `RecommendationRequestController` with endpoints for listing and creating recommendation requests, and adding corresponding tests to verify authorization and database interactions.

**New Controller Implementation:**

* Added `RecommendationRequestController` with two endpoints:
  - `GET /api/RecommendationRequest/all`: Lists all recommendation requests, accessible to users with the `USER` role.
  - [`POST /api/RecommendationRequest/post`](diffhunk://#diff-7eabb5beaee033c6ed33edaca02702c7b581ea96acf798e4b77fbd8083558dfdR1-R97): Allows admins to create a new recommendation request, with parameters for requester email, professor email, explanation, dates, and completion status.

**Testing and Authorization:**

* Added `RecommendationRequestControllerTests` covering:
  - Authorization checks to ensure only users with the correct roles can access each endpoint.
  - Mocked tests for listing all recommendation requests and creating a new one, verifying correct repository interactions and response content.