### PR TITLE
added GET by id for ucsborganization

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -1,0 +1,67 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** This is a REST controller for UCSBOrganization */
+@Tag(name = "UCSBOrganization")
+@RequestMapping("/api/ucsborganization")
+@RestController
+@Slf4j
+public class UCSBOrganizationController extends ApiController {
+
+  @Autowired UCSBOrganizationRepository UCSBOrganizationRepository;
+
+  /**
+   * THis method returns a list of all UCSBOrganizations.
+   *
+   * @return a list of all UCSBOrganizations
+   */
+  @Operation(summary = "List all ucsb organizations")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<UCSBOrganization> allOrgs() {
+    Iterable<UCSBOrganization> orgs = UCSBOrganizationRepository.findAll();
+    return orgs;
+  }
+
+  /**
+   * This method creates a new organization. Accessible only to users with the role "ROLE_ADMIN".
+   *
+   * @param orgCode org code of the organization
+   * @param orgTranslationShort translation of the organization's name
+   * @param orgTranslationLong translation of the organization's full name
+   * @param inactive whether the organization is inactive
+   * @return the save organization
+   */
+  @Operation(summary = "Create a new organization")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public UCSBOrganization postOrganization(
+      @Parameter(name = "orgCode") @RequestParam String orgCode,
+      @Parameter(name = "orgTranslationShort") @RequestParam String orgTranslationShort,
+      @Parameter(name = "orgTranslation") @RequestParam String orgTranslation,
+      @Parameter(name = "inactive") @RequestParam boolean inactive) {
+
+    UCSBOrganization organization = new UCSBOrganization();
+    organization.setOrgCode(orgCode);
+    organization.setOrgTranslationShort(orgTranslationShort);
+    organization.setOrgTranslation(orgTranslation);
+    organization.setInactive(inactive);
+
+    UCSBOrganization savedOrganization = UCSBOrganizationRepository.save(organization);
+
+    return savedOrganization;
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.example.controllers;
 
 import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -21,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class UCSBOrganizationController extends ApiController {
 
-  @Autowired UCSBOrganizationRepository UCSBOrganizationRepository;
+  @Autowired UCSBOrganizationRepository ucsbOrganizationRepository;
 
   /**
    * THis method returns a list of all UCSBOrganizations.
@@ -32,8 +33,26 @@ public class UCSBOrganizationController extends ApiController {
   @PreAuthorize("hasRole('ROLE_USER')")
   @GetMapping("/all")
   public Iterable<UCSBOrganization> allOrgs() {
-    Iterable<UCSBOrganization> orgs = UCSBOrganizationRepository.findAll();
+    Iterable<UCSBOrganization> orgs = ucsbOrganizationRepository.findAll();
     return orgs;
+  }
+
+  /**
+   * This method returns a single organization.
+   *
+   * @param orgCode code of the organization
+   * @return a single organization
+   */
+  @Operation(summary = "Get a single organization")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public UCSBOrganization getById(@Parameter(name = "orgCode") @RequestParam String orgCode) {
+    UCSBOrganization org =
+        ucsbOrganizationRepository
+            .findById(orgCode)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+    return org;
   }
 
   /**
@@ -60,7 +79,7 @@ public class UCSBOrganizationController extends ApiController {
     organization.setOrgTranslation(orgTranslation);
     organization.setInactive(inactive);
 
-    UCSBOrganization savedOrganization = UCSBOrganizationRepository.save(organization);
+    UCSBOrganization savedOrganization = ucsbOrganizationRepository.save(organization);
 
     return savedOrganization;
   }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -41,7 +41,7 @@ public class UCSBOrganizationController extends ApiController {
    *
    * @param orgCode org code of the organization
    * @param orgTranslationShort translation of the organization's name
-   * @param orgTranslationLong translation of the organization's full name
+   * @param orgTranslation translation of the organization's full name
    * @param inactive whether the organization is inactive
    * @return the save organization
    */

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
@@ -1,0 +1,25 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * This is a JPA entity that represents a UCSBOrganization
+ *
+ * <p>A UCSBOrganization is a dining commons at UCSB
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsborganization")
+public class UCSBOrganization {
+  @Id private String orgCode;
+  private String orgTranslationShort;
+  private String orgTranslation;
+  private boolean inactive;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
@@ -1,0 +1,11 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
+/** The UCSBOrganizationRepository is a repository for UCSBOrganization entities */
+@Repository
+@RepositoryRestResource(exported = false)
+public interface UCSBOrganizationRepository extends CrudRepository<UCSBOrganization, String> {}

--- a/src/main/resources/db/migration/changes/UCSBOrganization.json
+++ b/src/main/resources/db/migration/changes/UCSBOrganization.json
@@ -1,0 +1,62 @@
+{ "databaseChangeLog": [
+    {
+        "changeSet": {
+          "id": "UCSBOrganization-1",
+          "author": "Wendy192837",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "UCSBORGANIZATION"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "ORGANIZATION_PK"
+                      },
+                      "name": "ORG_CODE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "ORG_TRNSLATION_SHORT",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "ORG_TRANSLATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "INACTIVE",
+                      "type": "BOOLEAN"
+                    }
+                  }]
+                ,
+                "tableName": "UCSBORGANIZATION"
+              }
+            }]
+
+        }
+    }
+]}

--- a/src/main/resources/db/migration/changes/UCSBOrganization.json
+++ b/src/main/resources/db/migration/changes/UCSBOrganization.json
@@ -33,7 +33,7 @@
                   },
                   {
                     "column": {
-                      "name": "ORG_TRNSLATION_SHORT",
+                      "name": "ORG_TRANSLATION_SHORT",
                       "type": "VARCHAR(255)"
                     }
                   },

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -16,6 +16,8 @@ import edu.ucsb.cs156.example.repositories.UserRepository;
 import edu.ucsb.cs156.example.testconfig.TestConfig;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -27,7 +29,7 @@ import org.springframework.test.web.servlet.MvcResult;
 @Import(TestConfig.class)
 public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
-  @MockitoBean UCSBOrganizationRepository UCSBOrganizationRepository;
+  @MockitoBean UCSBOrganizationRepository ucsbOrganizationRepository;
 
   @MockitoBean UserRepository userRepository;
 
@@ -48,6 +50,13 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
         .andExpect(status().is(200)); // logged in users can get all
   }
 
+  @Test
+  public void logged_out_users_cannot_get_by_id() throws Exception {
+    mockMvc
+        .perform(get("/api/ucsborganization?orgCode=zpr"))
+        .andExpect(status().is(403)); // logged out users can't get by id
+  }
+
   // Authorization tests for /api/UCSBOrganization/post
   // (Perhaps should also have these for put and delete)
 
@@ -62,6 +71,62 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     mockMvc
         .perform(post("/api/ucsborganization/post"))
         .andExpect(status().is(403)); // only admins can post
+  }
+
+  // Tests with mocks for database actions
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+    // arrange
+
+    UCSBOrganization zpr =
+        UCSBOrganization.builder()
+            .orgCode("ZPR")
+            .orgTranslationShort("Zeta Phi Rho")
+            .orgTranslation("Zeta Phi Rho Fraternity")
+            .inactive(false)
+            .build();
+
+    when(ucsbOrganizationRepository.findById(eq("zpr"))).thenReturn(Optional.of(zpr));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/ucsborganization?orgCode=zpr"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+
+    verify(ucsbOrganizationRepository, times(1)).findById(eq("zpr"));
+    String expectedJson = mapper.writeValueAsString(zpr);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+    // arrange
+
+    when(ucsbOrganizationRepository.findById(eq("munger-hall"))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/ucsborganization?orgCode=munger-hall"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+
+    verify(ucsbOrganizationRepository, times(1)).findById(eq("munger-hall"));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("UCSBOrganization with id munger-hall not found", json.get("message"));
   }
 
   // Tests with mocks for database actions
@@ -91,7 +156,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     ArrayList<UCSBOrganization> expectedOrgs = new ArrayList<>();
     expectedOrgs.addAll(Arrays.asList(zpr, sky));
 
-    when(UCSBOrganizationRepository.findAll()).thenReturn(expectedOrgs);
+    when(ucsbOrganizationRepository.findAll()).thenReturn(expectedOrgs);
 
     // act
     MvcResult response =
@@ -99,7 +164,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
     // assert
 
-    verify(UCSBOrganizationRepository, times(1)).findAll();
+    verify(ucsbOrganizationRepository, times(1)).findAll();
     String expectedJson = mapper.writeValueAsString(expectedOrgs);
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
@@ -118,7 +183,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
             .inactive(true)
             .build();
 
-    when(UCSBOrganizationRepository.save(eq(zpr))).thenReturn(zpr);
+    when(ucsbOrganizationRepository.save(eq(zpr))).thenReturn(zpr);
 
     // act
     MvcResult response =
@@ -130,7 +195,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
             .andReturn();
 
     // assert
-    verify(UCSBOrganizationRepository, times(1)).save(zpr);
+    verify(ucsbOrganizationRepository, times(1)).save(zpr);
     String expectedJson = mapper.writeValueAsString(zpr);
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -1,0 +1,138 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = UCSBOrganizationController.class)
+@Import(TestConfig.class)
+public class UCSBOrganizationControllerTests extends ControllerTestCase {
+
+  @MockitoBean UCSBOrganizationRepository UCSBOrganizationRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  // Authorization tests for /api/UCSBOrganization/admin/all
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc
+        .perform(get("/api/ucsborganization/all"))
+        .andExpect(status().is(403)); // logged out users can't get all
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc
+        .perform(get("/api/ucsborganization/all"))
+        .andExpect(status().is(200)); // logged in users can get all
+  }
+
+  // Authorization tests for /api/UCSBOrganization/post
+  // (Perhaps should also have these for put and delete)
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc.perform(post("/api/ucsborganization/post")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(post("/api/ucsborganization/post"))
+        .andExpect(status().is(403)); // only admins can post
+  }
+
+  // Tests with mocks for database actions
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_UCSBOrganization() throws Exception {
+
+    // arrange
+
+    UCSBOrganization zpr =
+        UCSBOrganization.builder()
+            .orgCode("ZPR")
+            .orgTranslationShort("Zeta Phi Rho")
+            .orgTranslation("Zeta Phi Rho Fraternity")
+            .inactive(false)
+            .build();
+
+    UCSBOrganization sky =
+        UCSBOrganization.builder()
+            .orgCode("SKY")
+            .orgTranslationShort("Skydiving Club")
+            .orgTranslation("Skydiving Club at UCSB")
+            .inactive(true)
+            .build();
+
+    ArrayList<UCSBOrganization> expectedOrgs = new ArrayList<>();
+    expectedOrgs.addAll(Arrays.asList(zpr, sky));
+
+    when(UCSBOrganizationRepository.findAll()).thenReturn(expectedOrgs);
+
+    // act
+    MvcResult response =
+        mockMvc.perform(get("/api/ucsborganization/all")).andExpect(status().isOk()).andReturn();
+
+    // assert
+
+    verify(UCSBOrganizationRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedOrgs);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_commons() throws Exception {
+    // arrange
+
+    UCSBOrganization zpr =
+        UCSBOrganization.builder()
+            .orgCode("ZPR")
+            .orgTranslationShort("ZetaPhiRho")
+            .orgTranslation("ZetaPhiRhoFraternity")
+            .inactive(true)
+            .build();
+
+    when(UCSBOrganizationRepository.save(eq(zpr))).thenReturn(zpr);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/ucsborganization/post?orgCode=ZPR&orgTranslationShort=ZetaPhiRho&orgTranslation=ZetaPhiRhoFraternity&inactive=true")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(UCSBOrganizationRepository, times(1)).save(zpr);
+    String expectedJson = mapper.writeValueAsString(zpr);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+}


### PR DESCRIPTION
closes #60 

added get by id and tests for UCSBOrganization. 100% mutation and line coverage, swapper api testing below:

<img width="1244" height="685" alt="Screenshot 2026-04-22 at 18 43 33" src="https://github.com/user-attachments/assets/65035bfe-d6dd-47c1-a5b0-b16aad761c32" />
